### PR TITLE
[Feature] DNF 타임라인 아이템 필터링 데모 구현 (봇 연동은 추후 작업 예정)

### DIFF
--- a/dnf_api_timeline_demo.py
+++ b/dnf_api_timeline_demo.py
@@ -1,0 +1,94 @@
+import asyncio
+import aiohttp
+from core.db import get_all_characters_grouped_by_adventure
+from datetime import datetime, timedelta
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+API_KEY = os.getenv("NEOPLE_API_KEY")
+BASE_URL = "https://api.neople.co.kr/df"
+ITEM_DETAIL_CACHE = {}  # itemId별 장착 가능 레벨 캐시
+
+async def fetch_timeline(server_id: str, character_id: str):
+    url = f"{BASE_URL}/servers/{server_id}/characters/{character_id}/timeline"
+
+    start_date = (datetime.now() - timedelta(days=30)).strftime("%Y%m%dT%H%M")
+    end_date = datetime.now().strftime("%Y%m%dT%H%M")
+
+    params = {
+        "apikey": API_KEY,
+        "startDate": start_date,
+        "endDate": end_date,
+        "code": "505,504,507,508,513",
+        "limit": 100
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, params=params) as resp:
+            print(f"API 호출 상태 코드: {resp.status}")
+            data = await resp.json()
+            if resp.status == 200:
+                return data
+            else:
+                print(f"API 호출 실패: HTTP {resp.status}")
+                return None
+
+async def fetch_item_detail(session: aiohttp.ClientSession, item_id: str):
+    if item_id in ITEM_DETAIL_CACHE:
+        return ITEM_DETAIL_CACHE[item_id]
+
+    url = f"{BASE_URL}/items/{item_id}"
+    params = {"apikey": API_KEY}
+
+    async with session.get(url, params=params) as resp:
+        if resp.status == 200:
+            data = await resp.json()
+            equip_level = data.get("itemAvailableLevel", 0)
+            ITEM_DETAIL_CACHE[item_id] = equip_level
+            return equip_level
+        else:
+            print(f"아이템 상세 조회 실패: HTTP {resp.status} - {item_id}")
+            ITEM_DETAIL_CACHE[item_id] = 0
+            return 0
+
+async def filter_valid_items(timeline_rows, session):
+    valid_items = []
+    for row in timeline_rows:
+        item_id = row.get("data", {}).get("itemId")
+        if not item_id:
+            continue
+        equip_level = await fetch_item_detail(session, item_id)
+        if equip_level == 115:  # 장착 가능 레벨 조건
+            valid_items.append(row)
+    return valid_items
+
+async def main():
+    grouped = await get_all_characters_grouped_by_adventure()
+    if not grouped:
+        print("DB에 등록된 캐릭터가 없습니다.")
+        return
+
+    first_adventure = next(iter(grouped))
+    characters = grouped[first_adventure]
+    if not characters:
+        print("선택한 모험단에 캐릭터가 없습니다.")
+        return
+
+    char = characters[0]
+    print(f"조회할 캐릭터: {char['character_name']} ({char['character_id']}) 서버: {char['server_id']}")
+
+    timeline = await fetch_timeline(char['server_id'], char['character_id'])
+    if timeline is None or "timeline" not in timeline or "rows" not in timeline["timeline"]:
+        print("타임라인 데이터를 받아오지 못했습니다.")
+        return
+
+    async with aiohttp.ClientSession() as session:
+        filtered_items = await filter_valid_items(timeline["timeline"]["rows"], session)
+
+    print(f"장착 가능 레벨 115 아이템 {len(filtered_items)}개:")
+    for item in filtered_items:
+        print(item)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
이번 풀 리퀘스트에서는 네오플 던전앤파이터 API와 연동하는 새 스크립트 `dnf_api_timeline_demo.py`를 추가했습니다.  
해당 스크립트는 캐릭터의 타임라인 데이터를 조회하고, 아이템 상세 정보를 비동기적으로 가져오며, 장착 가능 레벨 115인 아이템만 필터링하는 기능을 포함합니다. 아이템 상세 정보는 캐싱하여 불필요한 API 호출을 줄였습니다.

### 주요 기능 및 작업 내용

- **API 연동 및 데이터 조회**  
  - `fetch_timeline` 함수: 캐릭터의 타임라인 데이터를 조회 (기간, 이벤트 코드 파라미터 포함)  
  - `fetch_item_detail` 함수: 아이템 상세 정보(장착 가능 레벨 포함)를 조회하며 캐싱 적용

- **필터링 및 검증**  
  - `filter_valid_items` 함수: 장착 가능 레벨이 115인 아이템만 필터링하여 반환

- **스크립트 실행 흐름**  
  - `main` 함수: 모험단별 캐릭터 목록 조회 → 타임라인 데이터 조회 → 필터링 순서로 작업 수행  
  - `.env` 파일 로딩을 통한 API 키 관리 적용
