### PR TITLE
feat: add item caching functionality with SQLite integration

### DIFF
--- a/dnf_api_timeline_demo.py
+++ b/dnf_api_timeline_demo.py
@@ -1,56 +1,11 @@
 import asyncio
+
 import aiohttp
+
+from core import dnf_api
 from core.db import get_all_characters_grouped_by_adventure
-from datetime import datetime, timedelta
-import os
-from dotenv import load_dotenv
+from core.db import init_db
 
-load_dotenv()
-API_KEY = os.getenv("NEOPLE_API_KEY")
-BASE_URL = "https://api.neople.co.kr/df"
-ITEM_DETAIL_CACHE = {}  # itemId별 장착 가능 레벨 캐시
-
-async def fetch_timeline(server_id: str, character_id: str):
-    url = f"{BASE_URL}/servers/{server_id}/characters/{character_id}/timeline"
-
-    start_date = (datetime.now() - timedelta(days=30)).strftime("%Y%m%dT%H%M")
-    end_date = datetime.now().strftime("%Y%m%dT%H%M")
-
-    params = {
-        "apikey": API_KEY,
-        "startDate": start_date,
-        "endDate": end_date,
-        "code": "505,504,507,508,513",
-        "limit": 100
-    }
-
-    async with aiohttp.ClientSession() as session:
-        async with session.get(url, params=params) as resp:
-            print(f"API 호출 상태 코드: {resp.status}")
-            data = await resp.json()
-            if resp.status == 200:
-                return data
-            else:
-                print(f"API 호출 실패: HTTP {resp.status}")
-                return None
-
-async def fetch_item_detail(session: aiohttp.ClientSession, item_id: str):
-    if item_id in ITEM_DETAIL_CACHE:
-        return ITEM_DETAIL_CACHE[item_id]
-
-    url = f"{BASE_URL}/items/{item_id}"
-    params = {"apikey": API_KEY}
-
-    async with session.get(url, params=params) as resp:
-        if resp.status == 200:
-            data = await resp.json()
-            equip_level = data.get("itemAvailableLevel", 0)
-            ITEM_DETAIL_CACHE[item_id] = equip_level
-            return equip_level
-        else:
-            print(f"아이템 상세 조회 실패: HTTP {resp.status} - {item_id}")
-            ITEM_DETAIL_CACHE[item_id] = 0
-            return 0
 
 async def filter_valid_items(timeline_rows, session):
     valid_items = []
@@ -58,10 +13,11 @@ async def filter_valid_items(timeline_rows, session):
         item_id = row.get("data", {}).get("itemId")
         if not item_id:
             continue
-        equip_level = await fetch_item_detail(session, item_id)
+        equip_level = await dnf_api.fetch_item_detail(session, item_id)
         if equip_level == 115:  # 장착 가능 레벨 조건
             valid_items.append(row)
     return valid_items
+
 
 async def main():
     grouped = await get_all_characters_grouped_by_adventure()
@@ -78,7 +34,7 @@ async def main():
     char = characters[0]
     print(f"조회할 캐릭터: {char['character_name']} ({char['character_id']}) 서버: {char['server_id']}")
 
-    timeline = await fetch_timeline(char['server_id'], char['character_id'])
+    timeline = await dnf_api.fetch_timeline(char['server_id'], char['character_id'])
     if timeline is None or "timeline" not in timeline or "rows" not in timeline["timeline"]:
         print("타임라인 데이터를 받아오지 못했습니다.")
         return
@@ -90,5 +46,7 @@ async def main():
     for item in filtered_items:
         print(item)
 
+
 if __name__ == "__main__":
+    asyncio.run(init_db())
     asyncio.run(main())


### PR DESCRIPTION
# [Feature] DNF 아이템 상세 정보 SQLite 캐싱 구현 #8

이 PR은 중복된 API 호출을 줄이고 성능을 향상시키기 위해 아이템 상세 정보에 대한 캐싱 메커니즘을 도입합니다. 데이터베이스 스키마 업데이트, 캐시 관련 유틸리티 함수 추가, 기존 코드 수정 등을 포함합니다.

---

## 데이터베이스 업데이트 및 캐시 구현

- [`core/db.py`](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbR34-R39):  
  `item_cache` 테이블을 새로 추가하여 `item_id`와 `item_available_level` 같은 아이템 정보를 저장합니다.  
  캐시된 아이템 정보를 조회하고 저장하는 `get_item_available_level`과 `save_item_available_level` 유틸리티 함수도 함께 구현했습니다. [[1]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbR34-R39) [[2]](diffhunk://#diff-10d8b8df635649476dd58e87855b025493578cf7d22dcb86515135d0b0e765fbR140-R175)

---

## API 통합 및 캐시 활용

- [`core/dnf_api.py`](diffhunk://#diff-7abb54803e10081d25c2ef8dc751cb78eecb4227b33bc4541d0875f00715c079R83-R155):  
  `fetch_item_detail` 함수 구현  
  - 아이템 상세 정보를 먼저 캐시에서 조회  
  - 캐시에 없으면 API 호출 후 DB 캐시에 저장하는 로직 적용

---

## 캐시 사용을 위한 리팩토링

- [`dnf_api_timeline_demo.py`](diffhunk://#diff-ab1cf968fbd94c4dc538433e0de460855bef09be05e4342f3911e13e882764d0L2-R21):  
  기존 메모리 기반 캐시를 제거하고 `core/dnf_api`의 DB 기반 `fetch_item_detail` 함수를 사용하도록 수정하여 일관된 캐시 활용을 보장함 [[1]](diffhunk://#diff-ab1cf968fbd94c4dc538433e0de460855bef09be05e4342f3911e13e882764d0L2-R21) [[2]](diffhunk://#diff-ab1cf968fbd94c4dc538433e0de460855bef09be05e4342f3911e13e882764d0L81-R37)

---

## 초기화 개선

- [`dnf_api_timeline_demo.py`](diffhunk://#diff-ab1cf968fbd94c4dc538433e0de460855bef09be05e4342f3911e13e882764d0R49-R51):  
  스크립트 시작 시점에 `init_db()` 호출 추가로 DB 초기화 보장

---

### 요약

이번 작업으로 아이템 관련 작업의 효율성과 유지보수성이 개선되었으며, 지속 가능한 DB 캐싱 메커니즘을 활용하여 불필요한 API 호출을 최소화합니다.

---

Closes #8
