### PR TITLE
 [enhancement] 레전더리 아이템 출력 필터링 추가 밑 출력 포맷 변경

### DIFF
--- a/tasks/notify_items.py
+++ b/tasks/notify_items.py
@@ -27,8 +27,7 @@ def get_rarity_color(rarity: str) -> int:
     }
     return mapping.get(rarity, 0x000000)  # 기본 검정
 
-def format_item_announce_embed(server_id, character_name, item_name, item_rarity, event_date):
-    server_name = SERVER_MAP.get(server_id, server_id)
+def format_item_announce_embed(adventure_name, character_name, item_name, item_rarity, event_date):
     import datetime
     dt = datetime.datetime.strptime(event_date, "%Y-%m-%d %H:%M")
     date_str = dt.strftime("%Y.%m.%d(%H:%M)")
@@ -36,7 +35,7 @@ def format_item_announce_embed(server_id, character_name, item_name, item_rarity
     color = get_rarity_color(item_rarity)
 
     embed = discord.Embed(
-        description=f"{server_name} 서버의 {character_name} 모험가가 {item_name}[{item_rarity}](을)를 획득했습니다.",
+        description=f"{adventure_name} 모험단의 {character_name} 모험가가 {item_name}[{item_rarity}](을)를 획득했습니다.",
         color=color
     )
     embed.set_footer(text=date_str)
@@ -53,6 +52,8 @@ async def filter_valid_items(timeline_rows):
         if equip_level == 115:
             valid_items.append(row)
     return valid_items
+
+# ... 기존 코드 유지 ...
 
 async def notify_items_for_character(session, char, bot, guild_id):
     character_id = char['character_id']
@@ -80,6 +81,12 @@ async def notify_items_for_character(session, char, bot, guild_id):
     rows = timeline["timeline"]["rows"]
     filtered_items = await filter_valid_items(rows)
 
+    # 레전더리 아이템 제외 필터링
+    filtered_items = [
+        item for item in filtered_items
+        if item.get("data", {}).get("itemRarity") in ("에픽", "태초")
+    ]
+
     # 디스코드 채널 조회
     channel_id = await get_output_channel(guild_id)
     if not channel_id:
@@ -96,10 +103,11 @@ async def notify_items_for_character(session, char, bot, guild_id):
             item_name = data.get("itemName", "알 수 없음")
             item_rarity = data.get("itemRarity", "알 수 없음")
             event_date = item.get("date", "")
-            embed = format_item_announce_embed(server_id, character_name, item_name, item_rarity, event_date)
+            embed = format_item_announce_embed(adventure_name, character_name, item_name, item_rarity, event_date)
             await channel.send(embed=embed)
 
     await update_last_checked(character_id, end_date)
+
 
 async def notify_all_characters(bot, guild_id):
     grouped = await get_all_characters_grouped_by_adventure()


### PR DESCRIPTION
# [enhancement] 레전더리 아이템 출력 필터링 추가 #13

이 풀 리퀘스트는 `tasks/notify_items.py` 내 아이템 알림 시스템을 리팩토링하여  
가독성과 기능성을 향상시켰습니다. 주요 변경 사항은 레전더리 아이템을 필터링하여 제외하고,  
알림에 에픽 및 태초 아이템만 포함되도록 했으며, 기존 코드 구조를 유지하여 가독성을 높인 점입니다.

---

## 주요 변경점

### 가독성 및 문맥 향상

- [`format_item_announce_embed`](tasks/notify_items.py):  
  알림 메시지에 `server_id` 대신 `adventure_name` (모험단명)을 사용하도록 변경하여  
  사용자에게 더 의미 있는 컨텍스트 제공  
  ([코드 위치](tasks/notify_items.py#L30-L38), [사용 부분](tasks/notify_items.py#L99-L111))

### 기능 개선

- [`notify_items_for_character`](tasks/notify_items.py):  
  알림 대상 아이템 중에서 레전더리 등급 아이템을 제외하고,  
  에픽과 태초 등급만 포함하도록 필터링 추가  
  ([코드 위치](tasks/notify_items.py#L84-L89))

### 코드 구조 유지

- [`filter_valid_items`](tasks/notify_items.py):  
  기존 함수 구조 유지, 변경 사항 없음 (주석만 추가)  
  ([코드 위치](tasks/notify_items.py#L56-L57))

---

closes #13
