### PR TITLE
[bug] 타임라인 API 중복 조회 데이터 필터링 #15

### DIFF
--- a/tasks/notify_items.py
+++ b/tasks/notify_items.py
@@ -14,7 +14,7 @@ from core.db import (
 from core.logger import logger
 from core.models import SERVER_MAP, ALLOWED_RARITIES  # 서버명 매핑용
 
-DEFAULT_PERIOD_MINUTES = 3
+DEFAULT_PERIOD_MINUTES = 2
 DEFAULT_LOOKBACK_MINUTES = 30  # 기록 없으면 최근 30분간 조회
 KST = timezone(timedelta(hours=9))
 


### PR DESCRIPTION
# [bug] 타임라인 API 중복 조회 데이터 필터링 #15

이 풀 리퀘스트는 캐릭터별로 최신 처리 시간을 캐싱하여 중복 아이템 처리 방지를 구현합니다.  
이로 인해 이벤트 타임스탬프를 기준으로 새 아이템만 처리되어, 효율성이 향상되고 중복 알림이 방지됩니다.

---

## 중복 필터링 기능 향상

- [`tasks/notify_items.py`](tasks/notify_items.py):  
  - 전역 캐시 `last_processed_time` 추가, 캐릭터별 마지막 처리 시간 저장  
  - `notify_items_for_character` 함수에 아이템 이벤트 시간 기준 중복 필터링 로직 구현  
  - 안전한 날짜 파싱용 헬퍼 함수 `parse_event_date` 추가

## 최신 처리 시간 캐싱

- [`tasks/notify_items.py`](tasks/notify_items.py):  
  - 처리 완료 후 캐릭터별 가장 최신 이벤트 시간을 `last_processed_time`에 업데이트  

---

closes #15
