### PR TITLE
[Feature] /오늘현황 명령어 추가 - 실시간 오늘 획득 아이템 집계 및 순위 표시 기능 구현 #23

### DIFF
--- a/commands/today_status.py
+++ b/commands/today_status.py
@@ -1,0 +1,34 @@
+from discord import app_commands, Interaction
+from datetime import datetime, timedelta
+from tasks.daily_aggregation import aggregate_items_and_notify_for_period  # 기간 지정 집계 함수
+import pytz
+
+KST = pytz.timezone('Asia/Seoul')
+
+
+def get_today_period(now: datetime):
+    today_6am = now.replace(hour=6, minute=0, second=0, microsecond=0)
+    if now < today_6am:
+        start_time = today_6am - timedelta(days=1)  # 어제 6시
+    else:
+        start_time = today_6am  # 오늘 6시
+    end_time = now
+    return start_time, end_time
+
+
+@app_commands.command(name="오늘현황", description="오늘 지금까지의 모험단 아이템 획득량을 집계해 보여줍니다.")
+async def today_status(interaction: Interaction):
+    now = datetime.now(KST)
+    start_time, end_time = get_today_period(now)
+
+    await aggregate_items_and_notify_for_period(
+        interaction.client,  # 봇 인스턴스
+        str(interaction.guild_id),  # 길드 ID
+        start_time,
+        end_time
+    )
+
+    await interaction.response.send_message(
+        f"오늘 {start_time.strftime('%m/%d %H:%M')}부터 {end_time.strftime('%m/%d %H:%M')}까지 집계를 완료했습니다.",
+        ephemeral=True
+    )

--- a/main.py
+++ b/main.py
@@ -28,11 +28,13 @@ class JongminiBot(commands.Bot):
         from commands.register import register_command
         from commands.total import total_command
         from commands.set_output_channel import set_output_channel
+        from commands.today_status import today_status
 
         self.tree.add_command(hello_command)
         self.tree.add_command(register_command)
         self.tree.add_command(total_command)
         self.tree.add_command(set_output_channel)
+        self.tree.add_command(today_status)
 
         await self.tree.sync()
         logger.info(f"슬래시 명령어 동기화 완료: {self.tree.get_commands()}")

--- a/tasks/daily_aggregation.py
+++ b/tasks/daily_aggregation.py
@@ -18,8 +18,9 @@ KST = timezone(timedelta(hours=9))
 
 MAX_RETRY_DURATION = 7 * 60 * 60  # 7시간
 RETRY_INTERVAL = 60  # 1분
-CONCURRENT_REQUEST_LIMIT = 10  # 동시 요청 제한
+CONCURRENT_REQUEST_LIMIT = 10  # 동시 캐릭터 처리 제한
 MAX_ITEM_CONCURRENT = 20  # 아이템 레벨 조회 동시 제한
+
 
 async def fetch_character_timeline_all_with_long_retry(server_id, character_id, start_date, end_date):
     start_time = datetime.now().timestamp()
@@ -37,6 +38,7 @@ async def fetch_character_timeline_all_with_long_retry(server_id, character_id, 
             return None
 
         await asyncio.sleep(RETRY_INTERVAL)
+
 
 async def filter_items_level_115(items):
     semaphore = asyncio.Semaphore(MAX_ITEM_CONCURRENT)
@@ -58,6 +60,24 @@ async def filter_items_level_115(items):
     return [item for item in results if item is not None]
 
 
+async def process_character(char, adventure_name, start_date_str, end_date_str, adventure_item_counts, semaphore):
+    server_id = char["server_id"]
+    character_id = char["character_id"]
+    async with semaphore:
+        timeline_data = await fetch_character_timeline_all_with_long_retry(
+            server_id, character_id, start_date_str, end_date_str
+        )
+        if not timeline_data:
+            logger.warning(f"{char['character_name']} 타임라인 조회 실패")
+            return
+        rows = timeline_data.get("timeline", {}).get("rows", [])
+        filtered_rows = await filter_items_level_115(rows)
+        for item in filtered_rows:
+            rarity = item.get("data", {}).get("itemRarity")
+            if rarity in RARITY_WEIGHTS:
+                adventure_item_counts[adventure_name][rarity] += 1
+
+
 def format_rank_embed(rank_list, timestamp):
     embed = discord.Embed(
         title="모험단 일간 아이템 획득량 순위",
@@ -71,12 +91,8 @@ def format_rank_embed(rank_list, timestamp):
         embed.add_field(name=f"{i}위 {entry['adventure_name']}", value=line, inline=False)
     return embed
 
-async def aggregate_daily_items_and_notify(bot, guild_id):
-    now = datetime.now(KST)
-    today_6am = now.replace(hour=6, minute=0, second=0, microsecond=0)
-    start_time = today_6am - timedelta(days=1)  # 전날 6시
-    end_time = today_6am - timedelta(seconds=1)  # 오늘 5시 59분 59초
 
+async def aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_time):
     start_date_str = start_time.strftime("%Y%m%dT%H%M")
     end_date_str = end_time.strftime("%Y%m%dT%H%M")
 
@@ -86,34 +102,13 @@ async def aggregate_daily_items_and_notify(bot, guild_id):
         return
 
     adventure_item_counts = defaultdict(lambda: defaultdict(int))
-    semaphore = asyncio.Semaphore(CONCURRENT_REQUEST_LIMIT)  # 동시 캐릭터 처리 제한
-
-    async def process_character(char, adventure_name):
-        server_id = char["server_id"]
-        character_id = char["character_id"]
-        async with semaphore:
-            timeline_data = await fetch_character_timeline_all_with_long_retry(
-                server_id, character_id, start_date_str, end_date_str
-            )
-            if not timeline_data:
-                logger.warning(f"{char['character_name']} 타임라인 조회 실패")
-                return
-            rows = timeline_data.get("timeline", {}).get("rows", [])
-
-            # 115레벨 필터링 최적화된 호출
-            filtered_rows = await filter_items_level_115(rows)
-
-            for item in filtered_rows:
-                rarity = item.get("data", {}).get("itemRarity")
-                if rarity in RARITY_WEIGHTS:
-                    adventure_item_counts[adventure_name][rarity] += 1
+    semaphore = asyncio.Semaphore(CONCURRENT_REQUEST_LIMIT)
 
     tasks = [
-        process_character(char, adventure_name)
+        process_character(char, adventure_name, start_date_str, end_date_str, adventure_item_counts, semaphore)
         for adventure_name, characters in grouped.items()
         for char in characters
     ]
-
     await asyncio.gather(*tasks)
 
     adventure_scores = []
@@ -136,11 +131,21 @@ async def aggregate_daily_items_and_notify(bot, guild_id):
         logger.warning(f"채널 {channel_id}을 찾을 수 없습니다.")
         return
 
-    embed = format_rank_embed(adventure_scores, now)
+    embed = format_rank_embed(adventure_scores, datetime.now(KST))
     await channel.send(embed=embed)
-    logger.info("모험단 일간 획득량 순위 Discord에 전송 완료")
+    logger.info("모험단 아이템 획득량 순위 Discord에 전송 완료")
 
+
+async def aggregate_daily_items_and_notify(bot, guild_id):
+    now = datetime.now(KST)
+    today_6am = now.replace(hour=6, minute=0, second=0, microsecond=0)
+    start_time = today_6am - timedelta(days=1)
+    end_time = today_6am - timedelta(seconds=1)
+    await aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_time)
+
+    # 일간 자동 집계 작업만 DB 기록
     await update_last_aggregation_time(now.strftime("%Y%m%dT%H%M"))
+
 
 async def wait_until_next_6am():
     now = datetime.now(KST)
@@ -150,6 +155,7 @@ async def wait_until_next_6am():
     wait_seconds = (next_6am - now).total_seconds()
     logger.info(f"다음 6시까지 대기: {wait_seconds}초")
     await asyncio.sleep(wait_seconds)
+
 
 async def daily_aggregation_task(bot, guild_id):
     while True:


### PR DESCRIPTION
# [Feature] /오늘현황 명령어 추가 - 실시간 오늘 획득 아이템 집계 및 순위 표시 기능 구현 #23

이번 Pull Request는 지정된 기간 동안 아이템 획득 데이터를 집계 및 알림하는 새로운 기능을 추가하고, 일간 집계 로직을 리팩토링하며, 아이템 처리 동시성 관리 방식을 개선하는 내용을 담고 있습니다.

---

## 주요 변경 사항

### 1. 새로운 기능: `/오늘현황` 명령어 추가

- `commands/today_status.py`에 현재 시점까지 오늘의 아이템 획득 데이터를 집계하고 알림하는 `today_status` 명령어를 추가하였습니다.
- 관련 기간 계산 로직과 집계 결과를 Discord에 전송하는 기능이 포함되어 있습니다.
- `main.py`에 `today_status` 명령어를 등록하여 슬래시 명령어로 사용할 수 있도록 했습니다.

### 2. 일간 집계 로직 리팩토링

- 기존 `aggregate_daily_items_and_notify` 함수는 기간 지정이 가능한 `aggregate_items_and_notify_for_period` 함수로 리팩토링하여 코드 재사용성과 유연성을 높였습니다.
- 6시 정기 집계용 함수(`aggregate_daily_items_and_notify`)를 별도로 유지하여 기존 정기 집계 워크플로우와의 호환성을 보장했습니다.

### 3. 동시성 관리 개선

- 아이템 집계 시 캐릭터별 동시 처리 제한을 위해 `process_character` 함수 내에서 세마포어(semaphore)를 사용하여 API 호출 동시성을 효과적으로 제어하도록 개선하였습니다.
- 이를 통해 리소스 과부하 방지 및 효율적인 작업 수행이 가능해졌습니다.

### 4. 기타 개선사항

- `tasks/daily_aggregation.py` 내 주석을 보완하여 동시성 제한 목적을 명확히 하고, 코드 가독성을 높였습니다.
- 로그 메시지를 보다 명확하게 수정하여 작업 범위와 목적을 쉽게 이해할 수 있도록 하였습니다.

---

## closes

- [Feature] /오늘현황 명령어 추가 - 실시간 오늘 획득 아이템 집계 및 순위 표시 기능 구현 #23
