### PR TITLE
feat: increase concurrency limits and enhance item notification handling

### DIFF
--- a/commands/today_status.py
+++ b/commands/today_status.py
@@ -25,10 +25,6 @@ async def today_status(interaction: Interaction):
         interaction.client,  # 봇 인스턴스
         str(interaction.guild_id),  # 길드 ID
         start_time,
-        end_time
-    )
-
-    await interaction.response.send_message(
-        f"오늘 {start_time.strftime('%m/%d %H:%M')}부터 {end_time.strftime('%m/%d %H:%M')}까지 집계를 완료했습니다.",
-        ephemeral=True
+        end_time,
+        interaction=interaction
     )

--- a/tasks/daily_aggregation.py
+++ b/tasks/daily_aggregation.py
@@ -18,8 +18,8 @@ KST = timezone(timedelta(hours=9))
 
 MAX_RETRY_DURATION = 7 * 60 * 60  # 7시간
 RETRY_INTERVAL = 60  # 1분
-CONCURRENT_REQUEST_LIMIT = 10  # 동시 캐릭터 처리 제한
-MAX_ITEM_CONCURRENT = 20  # 아이템 레벨 조회 동시 제한
+CONCURRENT_REQUEST_LIMIT = 50  # 동시 캐릭터 처리 제한
+MAX_ITEM_CONCURRENT = 50  # 아이템 레벨 조회 동시 제한
 
 
 async def fetch_character_timeline_all_with_long_retry(server_id, character_id, start_date, end_date):
@@ -92,7 +92,7 @@ def format_rank_embed(rank_list, timestamp):
     return embed
 
 
-async def aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_time, base_time=None):
+async def aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_time, base_time=None, interaction=None):
     """
     기간(start_time~end_time) 동안 아이템 집계 및 Discord 알림
     base_time: embed 표시 기준 시각 (지정 없으면 현재 시각)
@@ -139,8 +139,21 @@ async def aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_t
         return
 
     embed = format_rank_embed(adventure_scores, base_time)
-    await channel.send(embed=embed)
-    logger.info("모험단 아이템 획득량 순위 Discord에 전송 완료")
+    if interaction is not None:
+        # 슬래시 커맨드로 호출된 경우, interaction.response로 바로 응답
+        await interaction.response.send_message(embed=embed)
+    else:
+        # 기존 방식: 등록된 출력 채널에 메시지 전송
+        channel_id = await get_output_channel(guild_id)
+        if not channel_id:
+            logger.warning(f"길드 {guild_id}에 등록된 출력 채널이 없습니다.")
+            return
+        channel = bot.get_channel(int(channel_id))
+        if not channel:
+            logger.warning(f"채널 {channel_id}을 찾을 수 없습니다.")
+            return
+        await channel.send(embed=embed)
+        logger.info("모험단 아이템 획득량 순위 Discord에 전송 완료")
 
 
 async def aggregate_daily_items_and_notify(bot, guild_id):

--- a/tasks/notify_items.py
+++ b/tasks/notify_items.py
@@ -66,81 +66,82 @@ async def filter_valid_items(timeline_rows):
     return valid_items
 
 
-async def notify_items_for_character(char, bot, guild_id):
-    character_id = char['character_id']
-    server_id = char['server_id']
-    character_name = char['character_name']
-    adventure_name = char.get('adventure_name', '모험단명 없음')
+async def notify_items_for_character(char, bot, guild_id, semaphore):
+    async with semaphore:
+        character_id = char['character_id']
+        server_id = char['server_id']
+        character_name = char['character_name']
+        adventure_name = char.get('adventure_name', '모험단명 없음')
 
-    last_checked = await get_last_checked(character_id)
-    now = datetime.now(KST)
-    end_date = now.strftime("%Y%m%dT%H%M")
+        last_checked = await get_last_checked(character_id)
+        now = datetime.now(KST)
+        end_date = now.strftime("%Y%m%dT%H%M")
 
-    if last_checked:
-        start_time = datetime.strptime(last_checked, "%Y%m%dT%H%M")
-        start_date = start_time.strftime("%Y%m%dT%H%M")
-    else:
-        lookback = now - timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
-        start_date = lookback.strftime("%Y%m%dT%H%M")
+        if last_checked:
+            start_time = datetime.strptime(last_checked, "%Y%m%dT%H%M")
+            start_date = start_time.strftime("%Y%m%dT%H%M")
+        else:
+            lookback = now - timedelta(minutes=DEFAULT_LOOKBACK_MINUTES)
+            start_date = lookback.strftime("%Y%m%dT%H%M")
 
-    timeline = await dnf_api.fetch_timeline(server_id, character_id, start_date=start_date, end_date=end_date)
-    if timeline is None or "timeline" not in timeline or "rows" not in timeline["timeline"]:
-        logger.warning(f"[{character_name}] 타임라인 데이터를 받아오지 못했습니다.")
-        await update_last_checked(character_id, end_date)
-        return
+        timeline = await dnf_api.fetch_timeline(server_id, character_id, start_date=start_date, end_date=end_date)
+        if timeline is None or "timeline" not in timeline or "rows" not in timeline["timeline"]:
+            logger.warning(f"[{character_name}] 타임라인 데이터를 받아오지 못했습니다.")
+            await update_last_checked(character_id, end_date)
+            return
 
-    rows = timeline["timeline"]["rows"]
-    filtered_items = await filter_valid_items(rows)
+        rows = timeline["timeline"]["rows"]
+        filtered_items = await filter_valid_items(rows)
 
-    # 레전더리 아이템 제외 필터링
-    filtered_items = [
-        item for item in filtered_items
-        if item.get("data", {}).get("itemRarity") in ALLOWED_RARITIES
-    ]
+        # 레전더리 아이템 제외 필터링
+        filtered_items = [
+            item for item in filtered_items
+            if item.get("data", {}).get("itemRarity") in ALLOWED_RARITIES
+        ]
 
-    # 이전 처리 시점 락을 걸고 읽기
-    async with last_processed_lock:
-        last_time = last_processed_time.get(character_id)
-
-    new_filtered_items = []
-    max_event_time = last_time  # 이번에 처리한 가장 최신 시간 추적
-
-    for item in filtered_items:
-        event_dt = parse_event_date(item)
-        if event_dt is None:
-            continue
-        if (last_time is None) or (event_dt > last_time):
-            new_filtered_items.append(item)
-            if (max_event_time is None) or (event_dt > max_event_time):
-                max_event_time = event_dt
-
-    filtered_items = new_filtered_items
-
-    # 디스코드 채널 조회
-    channel_id = await get_output_channel(guild_id)
-    if not channel_id:
-        logger.warning(f"길드 {guild_id}에 등록된 출력 채널이 없습니다.")
-        return
-    channel = bot.get_channel(int(channel_id))
-    if not channel:
-        logger.warning(f"채널 {channel_id}을 찾을 수 없습니다.")
-        return
-
-    if filtered_items:
-        for item in filtered_items:
-            data = item.get("data", {})
-            item_name = data.get("itemName", "알 수 없음")
-            item_rarity = data.get("itemRarity", "알 수 없음")
-            event_date = item.get("date", "")
-            embed = format_item_announce_embed(adventure_name, character_name, item_name, item_rarity, event_date)
-            await channel.send(embed=embed)
-
-    # 처리 완료한 가장 최신 시간 캐싱도 락 걸고 쓰기
-    if max_event_time is not None:
+        # 이전 처리 시점 락을 걸고 읽기
         async with last_processed_lock:
-            last_processed_time[character_id] = max_event_time
+            last_time = last_processed_time.get(character_id)
 
-    await update_last_checked(character_id, end_date)
+        new_filtered_items = []
+        max_event_time = last_time  # 이번에 처리한 가장 최신 시간 추적
+
+        for item in filtered_items:
+            event_dt = parse_event_date(item)
+            if event_dt is None:
+                continue
+            if (last_time is None) or (event_dt > last_time):
+                new_filtered_items.append(item)
+                if (max_event_time is None) or (event_dt > max_event_time):
+                    max_event_time = event_dt
+
+        filtered_items = new_filtered_items
+
+        # 디스코드 채널 조회
+        channel_id = await get_output_channel(guild_id)
+        if not channel_id:
+            logger.warning(f"길드 {guild_id}에 등록된 출력 채널이 없습니다.")
+            return
+        channel = bot.get_channel(int(channel_id))
+        if not channel:
+            logger.warning(f"채널 {channel_id}을 찾을 수 없습니다.")
+            return
+
+        if filtered_items:
+            for item in filtered_items:
+                data = item.get("data", {})
+                item_name = data.get("itemName", "알 수 없음")
+                item_rarity = data.get("itemRarity", "알 수 없음")
+                event_date = item.get("date", "")
+                embed = format_item_announce_embed(adventure_name, character_name, item_name, item_rarity, event_date)
+                await channel.send(embed=embed)
+
+        # 처리 완료한 가장 최신 시간 캐싱도 락 걸고 쓰기
+        if max_event_time is not None:
+            async with last_processed_lock:
+                last_processed_time[character_id] = max_event_time
+
+        await update_last_checked(character_id, end_date)
 
 
 async def notify_all_characters(bot, guild_id):
@@ -149,10 +150,12 @@ async def notify_all_characters(bot, guild_id):
         logger.info("DB에 등록된 캐릭터가 없습니다.")
         return
 
+    semaphore = asyncio.Semaphore(50)  # 최대 50개 동시 실행 제한
+
     async with aiohttp.ClientSession():
         for adventure, characters in grouped.items():
-            for char in characters:
-                await notify_items_for_character(char, bot, guild_id)
+            tasks = [notify_items_for_character(char, bot, guild_id, semaphore) for char in characters]
+            await asyncio.gather(*tasks)
 
 
 async def periodic_notify(bot, guild_id):


### PR DESCRIPTION
# 📢 PR 내용: 타임라인 아이템 알림 병렬 처리 개선 (세마포어 적용)

이 PR은 코드베이스 전반에 걸쳐 동시성 한도 개선, Discord 명령어 내 상호작용 기반 응답 지원,  
세마포어를 활용한 리소스 관리 향상을 도입하여 성능 최적화와 사용자 인터랙션 처리 품질 향상을 목표로 합니다.

---

## 1. 동시성 및 리소스 관리 개선

- `tasks/daily_aggregation.py` 내 동시성 한도 증가  
  - `CONCURRENT_REQUEST_LIMIT` 10 → 50으로 상향  
  - `MAX_ITEM_CONCURRENT` 20 → 50으로 상향

- `tasks/notify_items.py` 내 세마포어 기반 동시성 제어 추가  
  - `notify_all_characters(bot, guild_id)` 함수에서 동시 실행 제한을 50으로 하는 세마포어 도입  
  - `notify_items_for_character` 함수에 세마포어 적용으로 동시 실행 관리 강화  

---

## 2. 상호작용 기반 Discord 명령어 응답 지원

- `commands/today_status.py` 내 `today_status(interaction: Interaction)` 함수가 하위 함수에 `interaction` 객체를 전달하도록 변경하여  
  직접적인 응답 처리가 가능하도록 개선

- `tasks/daily_aggregation.py` 내 `aggregate_items_and_notify_for_period` 함수가  
  - 슬래시 명령 호출 시 `interaction.response.send_message`로 직접 응답  
  - `interaction` 객체 미전달 시 기존처럼 등록된 출력 채널에 메시지 전송 방식 유지  

---

## 참고

- 세부 구현 내용 및 코드 변경 사항은 커밋 내 diff를 참고해 주세요.

---

closes #27