### PR TITLE
fix: correct pagination token retrieval and adjust period increment t…

### DIFF
--- a/core/dnf_api.py
+++ b/core/dnf_api.py
@@ -153,7 +153,7 @@ async def fetch_timeline_with_pagination(server_id: str, character_id: str, star
                 rows = timeline.get("rows", [])
                 all_rows.extend(rows)
 
-                next_token = data.get("next")
+                next_token = data.get("timeline", {}).get("next")
                 if not next_token:
                     break
 

--- a/tasks/daily_aggregation.py
+++ b/tasks/daily_aggregation.py
@@ -132,7 +132,7 @@ async def aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_t
         while current_start < end:
             current_end = min(current_start + timedelta(days=MAX_PERIOD_DAYS), end)
             periods.append((current_start, current_end))
-            current_start = current_end + timedelta(seconds=1)  # 중복 방지
+            current_start = current_end + timedelta(minutes=1)  # 중복 방지
         return periods
 
     periods = split_periods(start_time, end_time)


### PR DESCRIPTION
# PR 요약

이번 PR은 데이터 처리 개선과 페이징 및 기간 분할 로직의 엣지 케이스를 해결하는 두 가지 주요 변경사항을 포함합니다.

## 주요 변경사항

### 1. 페이징 처리 개선

- [`core/dnf_api.py`](diffhunk://#diff-7abb54803e10081d25c2ef8dc751cb78eecb4227b33bc4541d0875f00715c079L156-R156)  
  `fetch_timeline_with_pagination` 함수에서 `next_token`을 최상위 레벨이 아닌, API 응답 구조에 맞춰 중첩된 딕셔너리(`data.get("timeline", {}).get("next")`)에서 정확히 가져오도록 수정하였습니다.

### 2. 기간 분할 로직 조정

- [`tasks/daily_aggregation.py`](diffhunk://#diff-3d592ca712bfdcf04889991ef40f9a318e5ee696c91d6e5892eb681fad0d7982L135-R135)  
  `split_periods` 함수에서 `current_start`를 1초 단위가 아닌 1분 단위로 증가시키도록 변경하여 기간 겹침 가능성을 줄이고 시간 단위를 더 세밀하게 조정했습니다.

closes #31 
