### PR TITLE
Bug/fix duplicate timezone offset

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ async def on_ready():
     # 주간 집계: 매주 목요일 05:59 실행 (시간 그대로 유지)
     bot.scheduler.add_job(
         aggregate_weekly_items_and_notify,
-        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59, timezone=scheduler_tz),
+        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59),
         args=[bot, guild_id],
         id="weekly_aggregation_job",
         replace_existing=True
@@ -114,7 +114,7 @@ async def on_ready():
     # 월간 집계: 매월 1일 05:59 실행
     bot.scheduler.add_job(
         aggregate_monthly_items_and_notify,
-        trigger=CronTrigger(day=1, hour=5, minute=59, timezone=scheduler_tz),
+        trigger=CronTrigger(day=1, hour=5, minute=59),
         args=[bot, guild_id],
         id="monthly_aggregation_job",
         replace_existing=True
@@ -124,7 +124,7 @@ async def on_ready():
     # 캐릭터별 주간 집계: 매주 목요일 05:59 실행
     bot.scheduler.add_job(
         aggregate_weekly_items_by_character,
-        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59, timezone=scheduler_tz),
+        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59),
         args=[bot, guild_id],
         id="weekly_character_aggregation_job",
         replace_existing=True

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -32,10 +34,23 @@ load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN")
 
 
+def get_scheduler_timezone():
+    local_tz = datetime.now().astimezone().tzinfo
+    logger.info(f"시스템 로컬 타임존: {local_tz}")
+    if str(local_tz) == "Asia/Seoul":
+        logger.info("로컬 타임존이 Asia/Seoul 이므로 scheduler timezone 지정 안 함")
+        return None  # 시스템 로컬 시간대 사용
+    else:
+        seoul_tz = ZoneInfo("Asia/Seoul")
+        logger.info("로컬 타임존이 Asia/Seoul 아님, scheduler timezone을 Asia/Seoul로 지정함")
+        return seoul_tz
+
+
 class JongminiBot(commands.Bot):
     def __init__(self):
+        scheduler_tz = get_scheduler_timezone()
+        self.scheduler = AsyncIOScheduler(timezone=scheduler_tz)
         super().__init__(command_prefix="!", intents=discord.Intents.default())
-        self.scheduler = AsyncIOScheduler(timezone="Asia/Seoul")
         logger.info("JongminiBot 인스턴스 생성됨")
 
     async def setup_hook(self):
@@ -83,35 +98,38 @@ async def on_ready():
         bot.scheduler.start()
         logger.info("스케줄러 시작됨")
 
+    # 스케줄러 타임존 변수
+    scheduler_tz = bot.scheduler.timezone
+
     # 주간 집계: 매주 목요일 06:00 실행
     bot.scheduler.add_job(
         aggregate_weekly_items_and_notify,
-        trigger=CronTrigger(day_of_week="thu", hour=6, minute=0),
+        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59, timezone=scheduler_tz),
         args=[bot, guild_id],
         id="weekly_aggregation_job",
         replace_existing=True
     )
-    logger.info("주간 집계 작업 스케줄 등록됨 (매주 목요일 06:00)")
+    logger.info("주간 집계 작업 스케줄 등록됨 (매주 목요일 05:59)")
 
     # 월간 집계: 매월 1일 06:00 실행
     bot.scheduler.add_job(
         aggregate_monthly_items_and_notify,
-        trigger=CronTrigger(day=1, hour=6, minute=0),
+        trigger=CronTrigger(day=1, hour=5, minute=59, timezone=scheduler_tz),
         args=[bot, guild_id],
         id="monthly_aggregation_job",
         replace_existing=True
     )
-    logger.info("월간 집계 작업 스케줄 등록됨 (매월 1일 06:00)")
+    logger.info("월간 집계 작업 스케줄 등록됨 (매월 1일 05:59)")
 
-    # 캐릭터별 주간 집계: 매주 목요일 06:30 실행 (예시, 시간 조절 가능)
+    # 캐릭터별 주간 집계: 매주 목요일 06:01 실행
     bot.scheduler.add_job(
         aggregate_weekly_items_by_character,
-        trigger=CronTrigger(day_of_week="thu", hour=6, minute=1),
+        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59, timezone=scheduler_tz),
         args=[bot, guild_id],
         id="weekly_character_aggregation_job",
         replace_existing=True
     )
-    logger.info("캐릭터별 주간 집계 작업 스케줄 등록됨 (매주 목요일 06:01)")
+    logger.info("캐릭터별 주간 집계 작업 스케줄 등록됨 (매주 목요일 05:59)")
 
 
 bot.run(TOKEN)

--- a/main.py
+++ b/main.py
@@ -35,15 +35,10 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 
 
 def get_scheduler_timezone():
-    local_tz = datetime.now().astimezone().tzinfo
-    logger.info(f"시스템 로컬 타임존: {local_tz}")
-    if str(local_tz) == "Asia/Seoul":
-        logger.info("로컬 타임존이 Asia/Seoul 이므로 scheduler timezone 지정 안 함")
-        return None  # 시스템 로컬 시간대 사용
-    else:
-        seoul_tz = ZoneInfo("Asia/Seoul")
-        logger.info("로컬 타임존이 Asia/Seoul 아님, scheduler timezone을 Asia/Seoul로 지정함")
-        return seoul_tz
+    # UTC 고정
+    utc_tz = ZoneInfo("UTC")
+    logger.info(f"스케줄러 타임존으로 UTC 고정: {utc_tz}")
+    return utc_tz
 
 
 class JongminiBot(commands.Bot):
@@ -81,6 +76,11 @@ async def on_ready():
     logger.info(f"종미니 봇 로그인 성공: {bot.user}")
     print(f"✅ 종미니 봇 로그인 성공: {bot.user}")
 
+    # 현재 시간과 타임존 로그 출력
+    now = datetime.now(tz=bot.scheduler.timezone)
+    logger.info(f"현재 시간: {now.isoformat()} (타임존: {bot.scheduler.timezone})")
+    print(f"현재 시간: {now.isoformat()} (타임존: {bot.scheduler.timezone})")
+
     guild_id = "374494724725145600"  # 실제 서버 ID로 교체하세요
 
     # 기존 알림 task
@@ -101,7 +101,7 @@ async def on_ready():
     # 스케줄러 타임존 변수
     scheduler_tz = bot.scheduler.timezone
 
-    # 주간 집계: 매주 목요일 06:00 실행
+    # 주간 집계: 매주 목요일 05:59 실행 (시간 그대로 유지)
     bot.scheduler.add_job(
         aggregate_weekly_items_and_notify,
         trigger=CronTrigger(day_of_week="thu", hour=5, minute=59, timezone=scheduler_tz),
@@ -111,7 +111,7 @@ async def on_ready():
     )
     logger.info("주간 집계 작업 스케줄 등록됨 (매주 목요일 05:59)")
 
-    # 월간 집계: 매월 1일 06:00 실행
+    # 월간 집계: 매월 1일 05:59 실행
     bot.scheduler.add_job(
         aggregate_monthly_items_and_notify,
         trigger=CronTrigger(day=1, hour=5, minute=59, timezone=scheduler_tz),
@@ -121,7 +121,7 @@ async def on_ready():
     )
     logger.info("월간 집계 작업 스케줄 등록됨 (매월 1일 05:59)")
 
-    # 캐릭터별 주간 집계: 매주 목요일 06:01 실행
+    # 캐릭터별 주간 집계: 매주 목요일 05:59 실행
     bot.scheduler.add_job(
         aggregate_weekly_items_by_character,
         trigger=CronTrigger(day_of_week="thu", hour=5, minute=59, timezone=scheduler_tz),

--- a/main.py
+++ b/main.py
@@ -36,8 +36,8 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 
 def get_scheduler_timezone():
     # UTC 고정
-    utc_tz = ZoneInfo("UTC")
-    logger.info(f"스케줄러 타임존으로 UTC 고정: {utc_tz}")
+    utc_tz = ZoneInfo("Asia/Seoul")  # KST로 설정
+    logger.info(f"스케줄러 타임존으로 KST 고정: {utc_tz}")
     return utc_tz
 
 


### PR DESCRIPTION
# PR 요약: main.py 타임존 처리 개선 및 스케줄 작업 시간 조정

본 PR은 `main.py` 파일의 타임존 처리 방식을 개선하고, 스케줄된 작업 실행 시간을 조정하는 내용을 포함합니다. 주요 변경 사항은 다음과 같습니다.

---

## 타임존 처리 개선
- `datetime` 및 `ZoneInfo` 임포트 추가로 타임존 관리 기능 강화  
- `get_scheduler_timezone` 함수를 도입하여 스케줄러 타임존을 KST(`Asia/Seoul`)로 명확히 지정하고, 설정 정보를 로그로 출력하도록 구현  
- `JongminiBot` 클래스에서 스케줄러 초기화 시 하드코딩된 타임존 문자열 대신 `get_scheduler_timezone` 함수를 사용하도록 수정

---

## CronTrigger 타임존 명시 제거  
- 기존에 `CronTrigger`에 명시적으로 지정했던 타임존 옵션을 제거하여,  
- 스케줄러에 지정된 타임존과 중복 적용되는 문제를 방지하고 타임존 보정 충돌을 해결함

---

## 로그 출력 개선
- `async def on_ready()` 메서드에서 현재 시간과 타임존 정보를 로그 및 콘솔에 출력하도록 추가하여 봇 동작 상태를 보다 명확히 확인할 수 있게 함

---

## 스케줄러 작업 시간 조정
- 주간, 월간, 캐릭터별 주간 집계 작업의 실행 시간을 기존 `06:00` 또는 `06:01`에서 `05:59`로 변경하여 새로운 타임존 설정과 일관되게 조정  
- 이에 따른 로그 메시지도 함께 업데이트

---

위 변경사항을 통해 타임존 관련 이슈를 해소하고, 스케줄러가 의도한 시간에 정확히 작업을 수행하도록 개선하였습니다.


closes #33
