### PR TITLE
refactor: APScheduler 스케줄링 로직 백그라운드 태스크로 통합

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,9 +14,9 @@ from core.db import init_db
 
 # tasks import
 from tasks.daily_aggregation import daily_aggregation_task
-from tasks.monthly_aggregation import aggregate_monthly_items_and_notify
+from tasks.monthly_aggregation import monthly_aggregation_task
 from tasks.notify_items import periodic_notify
-from tasks.weekly_aggregation import aggregate_weekly_items_and_notify
+from tasks.weekly_aggregation import weekly_aggregation_task
 from tasks.weekly_character_aggregation import aggregate_weekly_items_by_character  # 캐릭터별 주간 집계 task
 
 # commands import
@@ -93,6 +93,16 @@ async def on_ready():
         bot.daily_aggregation_task = asyncio.create_task(daily_aggregation_task(bot, guild_id))
         logger.info("일간 모험단 집계 task 시작됨")
 
+    # 주간 집계 task
+    if not hasattr(bot, 'weekly_aggregation_task') or bot.weekly_aggregation_task.done():
+        bot.weekly_aggregation_task = asyncio.create_task(weekly_aggregation_task(bot, guild_id))
+        logger.info("주간 모험단 집계 task 시작됨")
+
+    # 월간 집계 task
+    if not hasattr(bot, 'monthly_aggregation_task') or bot.monthly_aggregation_task.done():
+        bot.monthly_aggregation_task = asyncio.create_task(monthly_aggregation_task(bot, guild_id))
+        logger.info("월간 모험단 집계 task 시작됨")
+
     # APScheduler 스케줄러 시작 및 작업 등록
     if not bot.scheduler.running:
         bot.scheduler.start()
@@ -100,26 +110,6 @@ async def on_ready():
 
     # 스케줄러 타임존 변수
     scheduler_tz = bot.scheduler.timezone
-
-    # 주간 집계: 매주 목요일 05:59 실행 (시간 그대로 유지)
-    bot.scheduler.add_job(
-        aggregate_weekly_items_and_notify,
-        trigger=CronTrigger(day_of_week="thu", hour=5, minute=59),
-        args=[bot, guild_id],
-        id="weekly_aggregation_job",
-        replace_existing=True
-    )
-    logger.info("주간 집계 작업 스케줄 등록됨 (매주 목요일 05:59)")
-
-    # 월간 집계: 매월 1일 05:59 실행
-    bot.scheduler.add_job(
-        aggregate_monthly_items_and_notify,
-        trigger=CronTrigger(day=1, hour=5, minute=59),
-        args=[bot, guild_id],
-        id="monthly_aggregation_job",
-        replace_existing=True
-    )
-    logger.info("월간 집계 작업 스케줄 등록됨 (매월 1일 05:59)")
 
     # 캐릭터별 주간 집계: 매주 목요일 05:59 실행
     bot.scheduler.add_job(

--- a/tasks/monthly_aggregation.py
+++ b/tasks/monthly_aggregation.py
@@ -1,6 +1,10 @@
+import asyncio
+from datetime import datetime, timedelta
+
 from .daily_aggregation import aggregate_items_and_notify_for_period
 from core.logger import logger
-from core.time_utils import get_monthly_period
+from core.time_utils import get_monthly_period, KST
+
 
 async def aggregate_monthly_items_and_notify(bot, guild_id):
     """
@@ -9,3 +13,37 @@ async def aggregate_monthly_items_and_notify(bot, guild_id):
     start_time, end_time = get_monthly_period()
     await aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_time, base_time=end_time, period="월간")
     logger.info("월간 모험단 아이템 집계 및 알림 완료")
+
+
+async def wait_until_next_month_1st_6am():
+    now = datetime.now(KST)
+    # Calculate the first day of the next month
+    if now.month == 12:
+        next_month_first_day = now.replace(year=now.year + 1, month=1, day=1)
+    else:
+        next_month_first_day = now.replace(month=now.month + 1, day=1)
+
+    next_run_time = next_month_first_day.replace(hour=6, minute=0, second=0, microsecond=0)
+
+    if now >= next_run_time:
+        # If it's already past 6am on the 1st, aim for the next month's 1st.
+        # This logic might need adjustment based on when the check runs.
+        # A simple addition of a month might not be safe due to varying days in months.
+        if next_run_time.month == 12:
+            next_run_time = next_run_time.replace(year=next_run_time.year + 1, month=1)
+        else:
+            next_run_time = next_run_time.replace(month=next_run_time.month + 1)
+
+    wait_seconds = (next_run_time - now).total_seconds()
+    logger.info(f"다음 월간 집계(1일 6시)까지 대기: {wait_seconds:.0f}초")
+    await asyncio.sleep(wait_seconds)
+
+
+async def monthly_aggregation_task(bot, guild_id):
+    """
+    매월 1일 6시 정기 집계 주기 작업
+    """
+    while True:
+        await wait_until_next_month_1st_6am()
+        logger.info("매월 1일 6시 정각 월간 집계 작업 실행")
+        await aggregate_monthly_items_and_notify(bot, guild_id)

--- a/tasks/weekly_aggregation.py
+++ b/tasks/weekly_aggregation.py
@@ -1,6 +1,10 @@
+import asyncio
+from datetime import datetime, timedelta
+
 from .daily_aggregation import aggregate_items_and_notify_for_period
 from core.logger import logger
-from core.time_utils import get_weekly_period
+from core.time_utils import get_weekly_period, KST
+
 
 async def aggregate_weekly_items_and_notify(bot, guild_id):
     """
@@ -9,3 +13,29 @@ async def aggregate_weekly_items_and_notify(bot, guild_id):
     start_time, end_time = get_weekly_period()
     await aggregate_items_and_notify_for_period(bot, guild_id, start_time, end_time, base_time=end_time, period="주간")
     logger.info("주간 모험단 아이템 집계 및 알림 완료")
+
+
+async def wait_until_next_thursday_6am():
+    now = datetime.now(KST)
+    # weekday() Monday is 0 and Sunday is 6. Thursday is 3.
+    days_until_thursday = (3 - now.weekday() + 7) % 7
+    next_thursday = now + timedelta(days=days_until_thursday)
+    next_run_time = next_thursday.replace(hour=6, minute=0, second=0, microsecond=0)
+
+    if now >= next_run_time:
+        # If it's already past 6am on Thursday, wait for next week's Thursday.
+        next_run_time += timedelta(weeks=1)
+
+    wait_seconds = (next_run_time - now).total_seconds()
+    logger.info(f"다음 주간 집계(목요일 6시)까지 대기: {wait_seconds:.0f}초")
+    await asyncio.sleep(wait_seconds)
+
+
+async def weekly_aggregation_task(bot, guild_id):
+    """
+    매주 목요일 6시 정기 집계 주기 작업
+    """
+    while True:
+        await wait_until_next_thursday_6am()
+        logger.info("목요일 6시 정각 주간 집계 작업 실행")
+        await aggregate_weekly_items_and_notify(bot, guild_id)


### PR DESCRIPTION
# PR 요약: APScheduler 스케줄링 로직 백그라운드 태스크로 통합

본 PR은 APScheduler를 이용한 주간/월간 집계 작업에서 발생하던 스케줄링 지연 문제를 해결하고, 관련 로직을 백그라운드 태스크로 통합하는 내용을 포함합니다.

---

## 문제점

기존 APScheduler를 이용한 주간/월간 집계 작업에서 스케줄링 지연 문제가 발생했습니다. 특히 오전 6시로 설정된 작업이 실제로는 오후 3시에 수행되는 현상이 관찰되었습니다. 이는 APScheduler의 특정 환경에서의 동작 문제 또는 타임존 설정과 관련된 복합적인 원인으로 인해 스케줄링된 작업이 의도된 시간에 정확히 실행되지 않고 지연되는 현상이 발생했습니다.

---

## 개선 내용

APScheduler에 직접 스케줄링하던 주간/월간 집계 로직을 제거하고, 봇의 `on_ready` 이벤트에서 `asyncio.create_task()`를 사용하여 해당 작업들을 백그라운드 태스크로 즉시 실행하도록 변경했습니다.

---

## 변경 사항 요약

- `main.py`에서 APScheduler를 이용한 주간/월간 집계 작업 스케줄링 코드 제거
- `on_ready()` 함수 내에서 `weekly_aggregation_task` 및 `monthly_aggregation_task`를 `asyncio.create_task()`로 백그라운드 실행
- 관련 임포트 경로 및 함수명 조정 (`aggregate_weekly_items_and_notify` -> `weekly_aggregation_task`, `aggregate_monthly_items_and_notify` -> `monthly_aggregation_task`)

---

## 기대 효과

- APScheduler의 스케줄링 지연 문제 해결
- 주간/월간 집계 작업이 봇 시작 시점에 안정적으로 백그라운드에서 실행되어, 의도된 시간에 가까운 시점에 데이터 집계 시작
- 모든 집계 작업 (일간, 주간, 월간)이 `asyncio` 기반으로 일관되게 관리되어 코드의 유지보수성 향상

---

closes #35