### PR TITLE
feat: 아이템 획득 알림 메시지 개선 및 경로별 포맷팅 추가

### DIFF
--- a/tasks/notify_items.py
+++ b/tasks/notify_items.py
@@ -42,15 +42,42 @@ def get_rarity_color(rarity: str) -> int:
     return mapping.get(rarity, 0x000000)  # 기본 검정
 
 
-def format_item_announce_embed(adventure_name, character_name, item_name, item_rarity, event_date):
+def format_item_announce_embed(adventure_name, character_name, item, event_date):
     import datetime
     dtstrp = datetime.datetime.strptime(event_date, "%Y-%m-%d %H:%M")
     date_str = dtstrp.strftime("%Y.%m.%d(%H:%M)")
 
+    code = item.get("code")
+    data = item.get("data", {})
+    item_name = data.get("itemName", "알 수 없음")
+    item_rarity = data.get("itemRarity", "알 수 없음")
+
     color = get_rarity_color(item_rarity)
 
+    description = f"{adventure_name} 모험단의 {character_name} 모험가가"
+
+    if code == 505:  # 던전 드랍
+        channel_name = data.get('channelName')
+        channel_no = data.get('channelNo')
+        dungeon_name = data.get('dungeonName')
+        description += f" {channel_name} {channel_no}채널 {dungeon_name}에서 드랍으로 {item_name}[{item_rarity}](을)를 획득했습니다."
+    elif code == 513:  # 던전 카드 보상
+        channel_name = data.get('channelName')
+        channel_no = data.get('channelNo')
+        dungeon_name = data.get('dungeonName')
+        description += f" {channel_name} {channel_no}채널 {dungeon_name}에서 던전 카드 보상으로 {item_name}[{item_rarity}](을)를 획득했습니다."
+    elif code == 504:  # 항아리/상자
+        channel_name = data.get('channelName')
+        channel_no = data.get('channelNo')
+        description += f" {channel_name} {channel_no}채널에서 항아리/상자에서 {item_name}[{item_rarity}](을)를 획득했습니다."
+    elif code == 507:  # 레이드 카드 보상
+        description += f" 레이드 카드 보상에서 {item_name}[{item_rarity}](을)를 획득했습니다."
+    else:
+        description += f" {item_name}[{item_rarity}](을)를 획득했습니다."
+
+
     embed = discord.Embed(
-        description=f"{adventure_name} 모험단의 {character_name} 모험가가 {item_name}[{item_rarity}](을)를 획득했습니다.",
+        description=description,
         color=color
     )
     embed.set_footer(text=date_str)
@@ -132,11 +159,8 @@ async def notify_items_for_character(char, bot, guild_id, semaphore):
 
         if filtered_items:
             for item in filtered_items:
-                data = item.get("data", {})
-                item_name = data.get("itemName", "알 수 없음")
-                item_rarity = data.get("itemRarity", "알 수 없음")
                 event_date = item.get("date", "")
-                embed = format_item_announce_embed(adventure_name, character_name, item_name, item_rarity, event_date)
+                embed = format_item_announce_embed(adventure_name, character_name, item, event_date)
                 await channel.send(embed=embed)
 
         # 처리 완료한 가장 최신 시간 캐싱도 락 걸고 쓰기

--- a/tasks/notify_items.py
+++ b/tasks/notify_items.py
@@ -69,7 +69,7 @@ def format_item_announce_embed(adventure_name, character_name, item, event_date)
     elif code == 504:  # 항아리/상자
         channel_name = data.get('channelName')
         channel_no = data.get('channelNo')
-        description += f" {channel_name} {channel_no}채널에서 항아리/상자에서 {item_name}[{item_rarity}](을)를 획득했습니다."
+        description += f" {channel_name} {channel_no}채널 항아리/상자에서 {item_name}[{item_rarity}](을)를 획득했습니다."
     elif code == 507:  # 레이드 카드 보상
         description += f" 레이드 카드 보상에서 {item_name}[{item_rarity}](을)를 획득했습니다."
     else:


### PR DESCRIPTION
# PR 요약: 아이템 획득 알림 메시지 개선: 획득 경로별 상세 정보 추가

본 PR은 `tasks/notify_items.py`의 아이템 획득 알림 기능을 개선하여, DNF API 응답의 `code` 값에 따라 획득 경로별로 상세하고 명확한 메시지를 제공하도록 수정합니다.

---

## 문제점

기존의 아이템 획득 알림은 모든 경로(던전 드랍, 카드 보상 등)에 대해 "ㅇㅇㅇ님이 아이템을 획득했습니다."와 같은 일관된 메시지를 출력했습니다. 이로 인해 사용자는 아이템을 구체적으로 어떻게 얻었는지 알 수 없어 정보가 부족했습니다.

---

## 개선 내용

`format_item_announce_embed` 함수를 수정하여 API 응답의 `code` 값을 기반으로 메시지를 동적으로 생성하도록 변경했습니다.

1.  **던전 드랍 (code: 505):**
    -   `{channelName} {channelNo}채널 {dungeonName} 에서 드랍으로 {itemName}[{itemRarity}](을)를 획득했습니다.`
2.  **던전 카드 보상 (code: 513):**
    -   `{channelName} {channelNo}채널 {dungeonName} 에서 던전 카드 보상으로 {itemName}[{itemRarity}](을)를 획득했습니다.`
3.  **항아리/상자 (code: 504):**
    -   `{channelName} {channelNo}채널에서 항아리/상자에서 {itemName}[{itemRarity}](을)를 획득했습니다.`
4.  **레이드 카드 보상 (code: 507):**
    -   `레이드 카드 보상에서 {itemName}[{itemRarity}](을)를 획득했습니다.`

---

## 변경 사항 요약

- `tasks/notify_items.py`의 `format_item_announce_embed` 함수 로직 수정
- 아이템 획득 `code`에 따라 메시지 포맷을 분기하는 조건문 추가
- 함수 호출 시 `item` 객체 전체를 전달하도록 변경

---

## 기대 효과

- 사용자가 아이템 획득 경로에 대한 상세 정보를 명확하게 파악할 수 있습니다.
- 알림 메시지의 가독성과 정보 전달력이 크게 향상됩니다.
- 봇의 기능성과 전반적인 사용자 경험이 개선됩니다.

---

closes #39