### PR TITLE
fix: replace alias import with direct import for datetime in notify_i…

### DIFF
--- a/tasks/notify_items.py
+++ b/tasks/notify_items.py
@@ -1,6 +1,5 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
-from datetime import datetime as dt
 import traceback  # traceback 모듈 추가
 
 import aiohttp
@@ -27,7 +26,7 @@ last_processed_lock = asyncio.Lock()
 
 def parse_event_date(item):
     try:
-        return dt.strptime(item.get("date", ""), "%Y-%m-%d %H:%M")
+        return datetime.strptime(item.get("date", ""), "%Y-%m-%d %H:%M")
     except ValueError:
         return None
 
@@ -43,9 +42,8 @@ def get_rarity_color(rarity: str) -> int:
 
 
 def format_item_announce_embed(adventure_name, character_name, item, event_date):
-    import datetime
-    dtstrp = datetime.datetime.strptime(event_date, "%Y-%m-%d %H:%M")
-    date_str = dtstrp.strftime("%Y.%m.%d(%H:%M)")
+    dt_pastime = datetime.strptime(event_date, "%Y-%m-%d %H:%M")
+    date_str = dt_pastime.strftime("%Y.%m.%d(%H:%M)")
 
     code = item.get("code")
     data = item.get("data", {})


### PR DESCRIPTION
This pull request includes several changes to the `tasks/notify_items.py` file, primarily focused on simplifying imports and improving consistency in how `datetime` is used across the codebase. Below is a summary of the most important changes:

### Import Simplification:

* Removed the redundant alias `datetime as dt` from the imports, as it was no longer used in the code.

### Consistent Usage of `datetime`:

* Updated the `parse_event_date` function to use `datetime.strptime` directly instead of the aliased `dt.strptime`, ensuring consistency with the rest of the code.
* Refactored the `format_item_announce_embed` function to replace `datetime.datetime.strptime` with `datetime.strptime` for clarity and consistency. Also renamed the variable `dtstrp` to `dt_pastime` for better readability.…tems.py

closes #41 